### PR TITLE
fix: improve version detection and Cloudflare deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,8 +91,15 @@ jobs:
       - name: Get latest version
         id: versioning
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          # Get all tags and sort them by version
+          LATEST_TAG=$(git tag -l "v*" | sort -V | tail -n 1 || echo "v0.0.0")
           CURRENT_VERSION=${LATEST_TAG#v}
+          
+          # If no version exists, start with 0.0.0
+          if [ -z "$CURRENT_VERSION" ]; then
+            CURRENT_VERSION="0.0.0"
+          fi
+          
           IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
           
           case "${{ steps.bump.outputs.bump }}" in
@@ -102,7 +109,7 @@ jobs:
             minor)
               NEW_VERSION="${major}.$((minor + 1)).0"
               ;;
-            patch)
+            *)
               NEW_VERSION="${major}.${minor}.$((patch + 1))"
               ;;
           esac


### PR DESCRIPTION
# Cloudflare Pages Deployment Integration

## Changes
1. Updated CI workflow to use Cloudflare Pages for deployment
2. Added Cloudflare-specific configuration and secrets
3. Removed redundant deployment workflow
4. Added VS Code settings to .gitignore

## Required Secrets
- `CLOUDFLARE_API_TOKEN`: API token from Cloudflare with Pages deployment permissions
- `CLOUDFLARE_ACCOUNT_ID`: Your Cloudflare account ID

## Testing
- [ ] CI workflow runs successfully
- [ ] Build completes without errors
- [ ] Site deploys to Cloudflare Pages
- [ ] Release creation works as expected

## Notes
- The site will be deployed to `blog-radaideh-info.pages.dev`
- Automatic deployments will happen on merges to main
- Preview deployments will be available for PRs

---
_This PR was prepared with the assistance of an AI agent (Claude) to ensure best practices and comprehensive documentation._ 