### PR TITLE
feat(about): add ITIL 5 Foundation certification

### DIFF
--- a/src/components/CertificateIcons.module.css
+++ b/src/components/CertificateIcons.module.css
@@ -37,6 +37,17 @@
   filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
 }
 
+.cert-icon-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: currentColor;
+}
+
 @media (max-width: 768px) {
   .certificate-icons {
     gap: 0.75rem;

--- a/src/components/CertificateIcons.tsx
+++ b/src/components/CertificateIcons.tsx
@@ -1,10 +1,11 @@
 import { motion } from 'framer-motion';
+import { certificateFallbackLabel } from '../lib/certificates';
 import styles from './CertificateIcons.module.css';
 
 export interface CertificateIcon {
   name: string;
-  imageUrl: string;
-  credlyUrl: string;
+  imageUrl?: string;
+  verifyUrl: string;
 }
 
 interface CertificateIconsProps {
@@ -17,7 +18,7 @@ export default function CertificateIcons({ certificates }: CertificateIconsProps
       {certificates.map((cert, index) => (
         <motion.a
           key={index}
-          href={cert.credlyUrl}
+          href={cert.verifyUrl}
           target="_blank"
           rel="noopener noreferrer"
           className={styles['cert-icon']}
@@ -27,7 +28,13 @@ export default function CertificateIcons({ certificates }: CertificateIconsProps
           transition={{ duration: 0.3, delay: index * 0.1 }}
           whileHover={{ scale: 1.15, y: -3 }}
         >
-          <img src={cert.imageUrl} alt={cert.name} loading="eager" />
+          {cert.imageUrl ? (
+            <img src={cert.imageUrl} alt={cert.name} loading="eager" />
+          ) : (
+            <span className={styles['cert-icon-fallback']}>
+              {certificateFallbackLabel(cert.name)}
+            </span>
+          )}
         </motion.a>
       ))}
     </div>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -2,6 +2,7 @@
 const pathname = Astro.url.pathname;
 import { SITE_TITLE } from '../consts';
 import { certificates } from '../data/certificates';
+import { certificateFallbackLabel } from '../lib/certificates';
 ---
 
 <nav class="nav-container">
@@ -12,14 +13,18 @@ import { certificates } from '../data/certificates';
         {
           certificates.map((cert) => (
             <a
-              href={cert.credlyUrl}
+              href={cert.verifyUrl}
               target="_blank"
               rel="noopener noreferrer"
               aria-label={cert.name}
               title={cert.name}
               class="cert-badge"
             >
-              <img src={cert.imageUrl} alt={cert.name} loading="lazy" />
+              {cert.imageUrl ? (
+                <img src={cert.imageUrl} alt={cert.name} loading="lazy" />
+              ) : (
+                <span class="cert-badge-fallback">{certificateFallbackLabel(cert.name)}</span>
+              )}
             </a>
           ))
         }
@@ -157,6 +162,17 @@ import { certificates } from '../data/certificates';
     height: 100%;
     object-fit: contain;
     display: block;
+  }
+
+  .cert-badge-fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: var(--text-color);
   }
 
   .nav-left a {

--- a/src/data/certificates.ts
+++ b/src/data/certificates.ts
@@ -1,7 +1,7 @@
 export interface Certificate {
   name: string;
-  imageUrl: string;
-  credlyUrl: string;
+  imageUrl?: string;
+  verifyUrl: string;
 }
 
 export const certificates: Certificate[] = [
@@ -9,30 +9,34 @@ export const certificates: Certificate[] = [
     name: 'Google Cloud Professional Cloud Architect',
     imageUrl:
       'https://images.credly.com/size/680x680/images/71c579e0-51fd-4247-b493-d2fa8167157a/image.png',
-    credlyUrl: 'https://www.credly.com/badges/28faf0f7-c4bd-4982-8993-85ebb22b4017',
+    verifyUrl: 'https://www.credly.com/badges/28faf0f7-c4bd-4982-8993-85ebb22b4017',
   },
   {
     name: 'Certified Kubernetes Administrator',
     imageUrl:
       'https://images.credly.com/size/680x680/images/8b8ed108-e77d-4396-ac59-2504583b9d54/cka_from_cncfsite__281_29.png',
-    credlyUrl: 'https://www.credly.com/badges/e3e549f9-0cc9-466a-92da-e5e06243a8e6',
+    verifyUrl: 'https://www.credly.com/badges/e3e549f9-0cc9-466a-92da-e5e06243a8e6',
   },
   {
     name: 'GitHub Actions',
     imageUrl:
       'https://images.credly.com/size/680x680/images/89efc3e7-842b-4790-b09b-9ea5efc71ec3/image.png',
-    credlyUrl: 'https://www.credly.com/badges/312ac168-3bd2-4ff1-a7bc-e64e64ddedcb',
+    verifyUrl: 'https://www.credly.com/badges/312ac168-3bd2-4ff1-a7bc-e64e64ddedcb',
   },
   {
     name: 'GIAC Advisory Board',
     imageUrl:
       'https://images.credly.com/size/680x680/images/efd77bd2-ab34-4323-b427-47b3e7136029/image.png',
-    credlyUrl: 'https://www.credly.com/badges/acc24d28-6a66-4a92-8fac-863b8992ae49',
+    verifyUrl: 'https://www.credly.com/badges/acc24d28-6a66-4a92-8fac-863b8992ae49',
   },
   {
     name: 'GIAC Security Essentials (GSEC)',
     imageUrl:
       'https://images.credly.com/size/680x680/images/8e6bde54-8a33-4ec0-9d70-90fcde581bcf/image.png',
-    credlyUrl: 'https://www.credly.com/badges/acc24d28-6a66-4a92-8fac-863b8992ae49',
+    verifyUrl: 'https://www.credly.com/badges/acc24d28-6a66-4a92-8fac-863b8992ae49',
+  },
+  {
+    name: 'ITIL 5 Foundation',
+    verifyUrl: 'https://www.peoplecert.org/public-profile?ed=XCHu3ZqUTNL7DkCzhKxFSrwuwhxZk4aq',
   },
 ];

--- a/src/lib/certificates.ts
+++ b/src/lib/certificates.ts
@@ -1,0 +1,9 @@
+export function certificateFallbackLabel(name: string): string {
+  const words = name.split(' ').filter((word) => /[A-Za-z0-9]/.test(word[0]));
+  const acronym = words.find((word) => /^[A-Z0-9]{2,6}$/.test(word));
+  if (acronym) return acronym;
+  return words
+    .slice(0, 2)
+    .map((word) => word[0].toUpperCase())
+    .join('');
+}


### PR DESCRIPTION
## 📋 Summary

Adds the ITIL 5 Foundation certification (credential ID GR428001994HA, issued March 2026, verified via PeopleCert) to the certifications list shown on the About page and nav bar.

## 🔧 Changes Made

- [x] Add ITIL 5 Foundation entry to `src/data/certificates.ts`, linking to the PeopleCert public profile
- [x] Generalize the certificate link field from `credlyUrl` to `verifyUrl` since this credential isn't issued via Credly
- [x] Make `imageUrl` optional and add a text-initials fallback badge (shared via `src/lib/certificates.ts`) for certifications without a badge image, used in both `CertificateIcons.tsx` and `Navigation.astro`

## 🧪 Testing

- [x] Manual testing completed (built site and confirmed the new badge renders on `/about` and in the nav)
- [ ] Playwright tests pass (not run in this session)

## 📚 Documentation

- [ ] README updated (if needed) — not needed
- [ ] Code comments added — not needed
- [ ] API documentation updated (if applicable) — n/a

## 🚀 Deployment Notes

- [ ] Environment variables updated (if needed) — none
- [ ] Database migrations (if applicable) — n/a
- [ ] Breaking changes documented — n/a (internal field rename only, no external consumers)

## ✅ Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] Linting passes (`npm run lint`)
- [x] Type checking passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwg3akZCcVdennzhEDhWHE)_