### PR TITLE
feat(blog): rewrite Cordless Terraform post to match site style

### DIFF
--- a/public/blog/cordless-terraform.svg
+++ b/public/blog/cordless-terraform.svg
@@ -1,0 +1,79 @@
+<svg width="1200" height="600" viewBox="0 0 1200 600" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="600" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1a1530"/>
+      <stop offset="1" stop-color="#241b3f"/>
+    </linearGradient>
+    <linearGradient id="line" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#844FBA"/>
+      <stop offset="1" stop-color="#B490E6"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="600" fill="url(#bg)"/>
+
+  <!-- faint grid -->
+  <g stroke="#3a2f5c" stroke-width="1" opacity="0.35">
+    <line x1="0" y1="150" x2="1200" y2="150"/>
+    <line x1="0" y1="450" x2="1200" y2="450"/>
+    <line x1="300" y1="0" x2="300" y2="600"/>
+    <line x1="900" y1="0" x2="900" y2="600"/>
+  </g>
+
+  <!-- Node 1: Input -->
+  <g transform="translate(120,250)">
+    <rect width="220" height="100" rx="14" fill="#2c2350" stroke="#5b4a8a" stroke-width="2"/>
+    <rect x="24" y="24" width="90" height="10" rx="5" fill="#B490E6"/>
+    <rect x="24" y="46" width="140" height="10" rx="5" fill="#6b5a99"/>
+    <rect x="24" y="68" width="110" height="10" rx="5" fill="#6b5a99"/>
+    <text x="110" y="-16" text-anchor="middle" fill="#cfc2ee" font-family="monospace" font-size="20" font-weight="600">INPUT ONLY</text>
+  </g>
+
+  <!-- arrow 1 -->
+  <path d="M340 300 H455" stroke="url(#line)" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <!-- Node 2: Workspace + Terraform -->
+  <g transform="translate(470,225)">
+    <rect width="260" height="150" rx="14" fill="#2c2350" stroke="#844FBA" stroke-width="2.5"/>
+    <!-- terraform-esque mark -->
+    <g transform="translate(30,35)">
+      <rect x="0" y="24" width="26" height="45" fill="#B490E6"/>
+      <rect x="30" y="0" width="26" height="45" fill="#844FBA"/>
+      <rect x="60" y="24" width="26" height="45" fill="#B490E6"/>
+      <rect x="30" y="48" width="26" height="45" fill="#5b4a8a"/>
+    </g>
+    <text x="150" y="55" text-anchor="middle" fill="#f1ecfb" font-family="monospace" font-size="20" font-weight="700">workspace</text>
+    <text x="150" y="80" text-anchor="middle" fill="#cfc2ee" font-family="monospace" font-size="15">select -or-create</text>
+    <text x="130" y="128" text-anchor="middle" fill="#8a7bb8" font-family="monospace" font-size="14">terraform apply</text>
+  </g>
+
+  <!-- arrow 2 -->
+  <path d="M730 300 H845" stroke="url(#line)" stroke-width="3" marker-end="url(#arrow)"/>
+
+  <!-- Node 3: Cloud -->
+  <g transform="translate(860,235)">
+    <rect width="220" height="130" rx="14" fill="#2c2350" stroke="#5b4a8a" stroke-width="2"/>
+    <g transform="translate(66,26)" fill="#B490E6">
+      <circle cx="20" cy="35" r="22"/>
+      <circle cx="48" cy="25" r="28"/>
+      <circle cx="78" cy="38" r="20"/>
+      <rect x="8" y="35" width="86" height="26" rx="13"/>
+    </g>
+    <text x="110" y="-16" text-anchor="middle" fill="#cfc2ee" font-family="monospace" font-size="20" font-weight="600">LIVE INFRA</text>
+  </g>
+
+  <!-- no code badge -->
+  <g transform="translate(510,430)">
+    <rect width="180" height="46" rx="23" fill="none" stroke="#B490E6" stroke-width="2"/>
+    <text x="90" y="30" text-anchor="middle" fill="#e4d9fb" font-family="monospace" font-size="17">no .tf in repo</text>
+  </g>
+
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#B490E6"/>
+    </marker>
+  </defs>
+
+  <text x="600" y="90" text-anchor="middle" fill="#f1ecfb" font-family="monospace" font-size="34" font-weight="700">CORDLESS TERRAFORM</text>
+  <text x="600" y="125" text-anchor="middle" fill="#8a7bb8" font-family="monospace" font-size="18">apply from any CI &#8212; no code, no commits</text>
+</svg>

--- a/src/content/blog/cordless-terraform-self-service-provisioning.mdx
+++ b/src/content/blog/cordless-terraform-self-service-provisioning.mdx
@@ -1,145 +1,66 @@
 ---
-title: 'Cordless Terraform: Applying Infrastructure Without a Single Line of Code in Your Repo'
-description: 'A CI-native pattern for self-service Terraform: shared modules, per-input workspaces, and ephemeral variables — no .tf files, no generated tfvars, nothing committed to your repository'
+title: 'Cordless Terraform: Apply Infrastructure With Zero Code in Your Repo'
+description: 'A CI-native pattern for self-service Terraform: shared module, per-input workspace, ephemeral variables — no .tf files, no commits, no GitOps overhead'
 pubDate: '2026-07-10'
+heroImage: '/blog/cordless-terraform.svg'
 ---
 
 import { Mermaid } from '../../components/Mermaid';
 
-### The Idea
+Want the full power of **Terraform providers and modules** — without a repo full of `.tf` files, without a PR for every environment, without GitOps ceremony?
 
-Every team that wants infrastructure ends up with the same conversation: "just give us a repo, write some Terraform, open a PR." That's fine for the platform team maintaining the modules. It's friction for everyone else — a service team that just needs a bucket, a queue, and a database doesn't want to learn HCL, doesn't want to own a `.tf` file, and definitely doesn't want to be responsible for a `terraform state` they'll never touch again.
+Give your CI pipeline **input only**, and let it do the rest.
 
-The approach I've been using strips that friction down to almost nothing:
+<Mermaid
+  client:load
+  chart={`graph LR
+    I[Input: form, API,<br/>or workflow_dispatch] --> S[Select / create<br/>workspace]
+    S --> A[terraform apply]
+    M[Shared module<br/>+ providers] --> A
+    A --> R[Live infrastructure]
 
-- A **shared Terraform module** (and the providers it needs) lives once, in a platform-owned location — never copied into consumer repos.
-- A **Terraform workspace** is selected or created per request, keyed off the caller's input (environment, team, resource name — whatever you choose as the key).
-- The CI system takes **input only** — a form, a `workflow_dispatch` payload, an API call — and feeds it straight into `terraform apply` as variables.
-- **Nothing gets committed.** No `.tf` file, no generated `tfvars` file, no scaffolding PR. The consumer's repository — if there even is one — never sees Terraform code.
+    style I fill:#e7f3ff
+    style M fill:#fff3cd
+    style R fill:#d4edda`}
 
-Before writing more code around this, I wanted to know: is this already a solved problem with a name, or am I reinventing something?
-
----
-
-### Is This a Known Pattern? Short Answer: Mostly, Yes
-
-Researching this landed on a clear picture: **the general category is well established and even productized**, but the specific shape — driven by _your own_ CI system, with _zero_ git footprint, not even generated files — is a thinner, less-documented corner of it.
-
-#### HashiCorp's own answer: No-Code Provisioning
-
-HCP Terraform and Terraform Enterprise ship an official feature called **[No-Code Provisioning](https://developer.hashicorp.com/terraform/tutorials/cloud/no-code-provisioning)**. A platform team marks a module version "No-code Ready" in the private registry; end users pick that module, fill in a web form for the variables, and HCP Terraform creates a workspace and runs the apply for them — [no HCL required](https://www.hashicorp.com/en/blog/terraform-without-writing-code-how-to-build-self-service-with-no-code-modules). This is, almost exactly, the pattern I'd sketched out — it's just tied to HashiCorp's own hosted "CI system" (HCP Terraform's run environment) rather than your GitHub Actions or GitLab CI pipeline, and it's a commercial-tier feature.
-
-#### The open-source approximations all commit _something_
-
-Looking at the OSS side — [Atlantis](https://spacelift.io/blog/atlantis-terragrunt) with a [Terragrunt catalog](https://github.com/transcend-io/terragrunt-atlantis-config), or [Backstage Software Templates](https://medium.com/@_gdantas/backstage-and-terraform-a-powerful-combination-for-ops-wonderful-for-devs-c04ebce849f0) backing a service catalog UI — the pattern is consistently: _the self-service experience is a form, but under the hood the automation still generates a `terragrunt.hcl` or `tfvars` file and commits it to version control._ That's a deliberate GitOps choice, not an oversight — [Gruntwork's guidance on self-service](https://docs.gruntwork.io/guides/production-framework/ingredients/self-service/how-self-service-should-work/) is explicit that even a slick UI should "operate via commits to version control" underneath, so the git history stays the source of truth for what's deployed.
-
-A few teams take this further with a fully issue-driven flow: a GitHub Issue form gets parsed into a config object, a script updates the environment's `tfvars` file, and a bot opens the PR automatically. It's self-service, but it's still git-mediated — a human-authored `.tf` file just gets replaced by a bot-authored `tfvars` file.
-
-#### Crossplane: the closest thing to truly code-free, but a different animal
-
-[Crossplane](https://blog.crossplane.io/crossplane-vs-terraform/) gets closest to "no code, ever" — a platform team defines a Composite Resource Definition (XRD) and Composition once, and a developer requests infrastructure with a few lines of YAML (a `Claim`), no Terraform involved at all. But it's architecturally a different beast: a Kubernetes control loop that reconciles continuously, not an on-demand `plan`/`apply` cycle, and it only makes sense if you're already running Crossplane inside a cluster.
-
-#### The gap
-
-| Approach                                 | Runs on                       | Consumer writes code? | Anything committed to git?               | Vendor lock-in |
-| ---------------------------------------- | ----------------------------- | --------------------- | ---------------------------------------- | -------------- |
-| Hand-written Terraform per team          | Any CI                        | Yes (`.tf`)           | Yes                                      | None           |
-| **HCP Terraform No-Code Provisioning**   | HCP Terraform's runners       | No                    | N/A (state lives in HCP)                 | HCP Terraform  |
-| Atlantis + Terragrunt catalog            | Any CI (PR-triggered)         | No (form/catalog)     | Yes — generated `terragrunt.hcl`         | None           |
-| Backstage Software Template              | Any CI (template commits)     | No (form)             | Yes — generated `tfvars`/`hcl`           | None           |
-| Crossplane Compositions                  | Kubernetes control loop       | No (YAML claim)       | Optional (claim can be applied directly) | Kubernetes     |
-| **Cordless: workspace + ephemeral vars** | **Your own CI, any provider** | **No**                | **No — nothing at all**                  | **None**       |
-
-That bottom-right cell is the gap: nobody else combines _your own CI system_ with _zero git footprint, including generated files_. That's the actual novelty here — not the self-service idea itself (that's well trodden), but skipping the "generate-and-commit" step that every OSS implementation treats as non-negotiable.
+/>
 
 ---
 
 ### How It Works
 
-<Mermaid
-  client:load
-  chart={`graph LR
-    subgraph "Caller"
-        I[Input: workflow_dispatch,<br/>API call, or form]
-    end
-
-    subgraph "CI Pipeline"
-        S[Select / create<br/>Terraform workspace]
-        V[Inject input as<br/>-var / TF_VAR_*]
-        A[terraform apply]
-    end
-
-    subgraph "Platform-owned, once"
-        M[Shared module +<br/>provider config]
-        B[Remote state backend<br/>keyed by workspace]
-    end
-
-    I --> S
-    S --> V
-    V --> A
-    M --> A
-    A --> B
-
-    style I fill:#e7f3ff
-    style M fill:#fff3cd
-    style B fill:#fff3cd`}
-
-/>
-
-Four pieces, and the discipline is in keeping each one exactly this narrow:
-
-1. **One module, one place.** The Terraform code — resources, providers, versions — is written once by the platform team and lives in a module registry or a fixed path the pipeline checks out at run time. Consumers never see it, let alone fork it.
-2. **Workspace per input, not per repo.** `terraform workspace select -or-create=true "$WORKSPACE_KEY"` derives the workspace name from the input (team name, environment, request ID). The workspace _is_ the record of "what was requested" — no separate config file needed to track it.
-3. **Variables travel as data, not as code.** Input arrives as CI parameters (`workflow_dispatch` inputs, an issue form, a JSON payload from an internal API) and gets passed straight to `terraform apply -var="size=${{ inputs.size }}"` or as `TF_VAR_*` environment variables. Nothing is written to disk beyond the ephemeral runner's workspace, which is discarded when the job ends.
-4. **State is the audit trail.** Because nothing is committed, `terraform state` plus the CI run's own logs (which already capture every input and every plan/apply output) become the record of what happened — not a git diff.
-
----
-
-### Reference Implementation
-
-A minimal `workflow_dispatch`-triggered example — no `tfvars`, no scaffolding, no PR:
+- **One module, one place.** Written once by the platform team, checked out at run time. Consumers never see it.
+- **Workspace per input, not per repo.** `terraform workspace select -or-create=true "$KEY"` — the workspace name _is_ the record of what was requested.
+- **Variables travel as data.** Input goes straight into `terraform apply -var=...` or `TF_VAR_*`. Nothing touches disk beyond the ephemeral CI runner.
+- **Nothing gets committed.** No `.tf`, no generated `tfvars`, no scaffolding PR.
 
 ```yaml
 name: Provision Resource
-
 on:
   workflow_dispatch:
     inputs:
-      team:
-        description: 'Requesting team'
-        required: true
-      environment:
-        description: 'Target environment'
-        required: true
-        type: choice
-        options: [dev, staging, prod]
-      size:
-        description: 'Instance size'
-        required: true
-        type: choice
-        options: [small, medium, large]
+      team: { required: true }
+      environment: { required: true, type: choice, options: [dev, staging, prod] }
+      size: { required: true, type: choice, options: [small, medium, large] }
 
 jobs:
   apply:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout shared module only
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: platform-team/terraform-modules
           path: module
 
       - uses: hashicorp/setup-terraform@v3
 
-      - name: Select or create workspace
-        working-directory: module
+      - working-directory: module
         run: |
           terraform init
           terraform workspace select -or-create=true \
             "${{ inputs.team }}-${{ inputs.environment }}"
 
-      - name: Apply from input only
-        working-directory: module
+      - working-directory: module
         env:
           TF_VAR_team: ${{ inputs.team }}
           TF_VAR_environment: ${{ inputs.environment }}
@@ -147,52 +68,29 @@ jobs:
         run: terraform apply -auto-approve
 ```
 
-The consumer's repository — if `workflow_dispatch` is triggered from one at all — contains this workflow file and nothing else. No module code, no `tfvars`, no state.
+Works the same in **GitLab CI, Jenkins, CircleCI, or any pipeline that can run a shell step** — nothing here is GitHub Actions-specific. Swap `workflow_dispatch` for a Jenkins parameterized build or a GitLab CI manual job and the rest is unchanged.
 
 ---
 
-### Trade-offs and Guardrails
+### Is This a Known Pattern?
 
-Nothing here is free. Skipping the "generate-and-commit" step that Atlantis and Backstage deliberately keep means giving up the audit trail git normally provides, and it opens the door to a specific new risk:
+Mostly. [HCP Terraform's No-Code Provisioning](https://developer.hashicorp.com/terraform/tutorials/cloud/no-code-provisioning) does almost exactly this — but it's HashiCorp's own hosted runner, not your CI. [Atlantis](https://spacelift.io/blog/atlantis-terragrunt), Terragrunt catalogs, and [Backstage](https://medium.com/@_gdantas/backstage-and-terraform-a-powerful-combination-for-ops-wonderful-for-devs-c04ebce849f0) self-service portals get the same UX but deliberately **commit a generated file to git** as their audit trail — that's a GitOps choice, not an accident. [Crossplane](https://blog.crossplane.io/crossplane-vs-terraform/) is the closest thing to truly code-free, but it's a Kubernetes control loop, not an on-demand apply.
 
-- **Audit trail moves from git to CI logs.** That's fine as long as your CI system retains run history and logs input values durably. If your CI logs rotate aggressively or you can't attribute a run to a human identity, you've lost the record `git blame` used to give you for free. Ship CI logs to long-term storage before relying on this.
-- **Unrestricted variable input is an injection surface.** If `size` becomes an arbitrary string instead of a `choice` enum, a caller can potentially reach variables the module author never intended to expose. Constrain every input to an enum or a validated pattern at the CI level (`type: choice` in the example above), and validate again inside the module with [`variable` validation blocks](https://developer.hashicorp.com/terraform/language/values/variables#custom-validation-rules) — never trust CI input as pre-sanitized.
-- **No plan-then-review gate by default.** PR-based flows get a human review step for free; this doesn't. Add a policy-as-code gate (OPA, Sentinel, or even a manual `environment` approval in GitHub Actions) between `plan` and `apply` if the blast radius warrants it — production workspaces especially.
-- **State sprawl.** One workspace per input scales fine until nobody remembers what half of them are for. Key the workspace name so it's self-describing, and add a scheduled job that lists workspaces with no corresponding CI runs in N days and flags them for cleanup.
+The gap: nobody else combines **your own CI, any provider** with **zero git footprint at all** — not even generated files.
 
 ---
 
-### When to Reach for This vs. Something Else
+### Trade-offs
 
-- **Already paying for HCP Terraform or Terraform Enterprise?** Use their native No-Code Provisioning — it's the same idea, hardened and supported, with version upgrade flows built in.
-- **Need a reviewable git history of every change, non-negotiably?** Use Atlantis or a Backstage-backed catalog — the generated-file-in-git step is a feature there, not overhead.
-- **Already running Crossplane in Kubernetes and want continuous reconciliation, not on-demand apply?** Use Compositions and Claims instead.
-- **Want self-service infrastructure driven entirely by your own CI, for low-blast-radius resources, without adopting a new platform?** This is the gap this pattern fills.
-
----
-
-### Key Takeaways
-
-1. **The category is solved; the specific shape isn't.** Self-service, no-code Terraform provisioning is a known, named, productized pattern (HCP Terraform No-Code Provisioning). A vendor-agnostic, zero-git-footprint version built on your own CI is the less-charted variant.
-2. **Every OSS approximation still commits something.** Atlantis, Terragrunt catalogs, and Backstage templates all intentionally generate and commit config — that's their audit trail. Skipping it is a trade-off, not a free win.
-3. **Workspace-per-input replaces file-per-environment.** The workspace name, derived from the input, is the record — you don't need a `tfvars` file to track what was requested.
-4. **Guardrails matter more here, not less.** Enum-constrained inputs, module-level validation, and a policy gate before `apply` are what keep "code-free" from becoming "review-free."
-
----
-
-### Conclusion
-
-This isn't a brand-new invention — it's a known category of self-service, no-code Terraform provisioning, with HashiCorp's own No-Code Provisioning as the productized reference. What's genuinely underexplored is the version that doesn't ask you to adopt HCP Terraform, Atlantis, Backstage, or Kubernetes to get there: a shared module, a workspace keyed by input, and variables that never touch disk longer than a single CI run. For low-risk, high-frequency provisioning requests, it's a lightweight way to get the self-service win without taking on a new platform.
+- **Audit trail moves from git to CI logs.** Ship them to long-term storage.
+- **Constrain every input.** Use `type: choice` enums, plus `variable` validation blocks in the module — never trust raw CI input.
+- **Add a policy gate before `apply`** on anything production-facing (OPA, Sentinel, or a manual approval environment).
 
 ---
 
 **Further Reading:**
 
-- [Terraform without writing code: How to build self-service with no-code modules](https://www.hashicorp.com/en/blog/terraform-without-writing-code-how-to-build-self-service-with-no-code-modules) — HashiCorp
-- [Create and use no-code modules](https://developer.hashicorp.com/terraform/tutorials/cloud/no-code-provisioning) — Terraform Docs
-- [Design no-code ready modules for HCP Terraform](https://developer.hashicorp.com/terraform/cloud-docs/no-code-provisioning/module-design) — Terraform Docs
-- [How Self-Service Should Work](https://docs.gruntwork.io/guides/production-framework/ingredients/self-service/how-self-service-should-work/) — Gruntwork
-- [Atlantis with Terragrunt: The Complete Guide](https://spacelift.io/blog/atlantis-terragrunt) — Spacelift
-- [Backstage and Terraform](https://medium.com/@_gdantas/backstage-and-terraform-a-powerful-combination-for-ops-wonderful-for-devs-c04ebce849f0) — Gabriel Dantas
+- [Terraform No-Code Provisioning](https://developer.hashicorp.com/terraform/tutorials/cloud/no-code-provisioning) — HashiCorp
+- [Atlantis with Terragrunt](https://spacelift.io/blog/atlantis-terragrunt) — Spacelift
 - [Crossplane vs Terraform](https://blog.crossplane.io/crossplane-vs-terraform/) — Crossplane
 - [Terraform custom validation rules](https://developer.hashicorp.com/terraform/language/values/variables#custom-validation-rules) — Terraform Docs


### PR DESCRIPTION
## 📋 Summary

Rewrites the "Cordless Terraform" post to match the site's shorter, punchier voice (like the ttyd/ngrok debugging post) instead of the long-form research writeup. Adds a custom SVG hero image, notes the pattern is CI-agnostic (GitLab CI, Jenkins, CircleCI), and reframes the goal around using Terraform providers/capabilities without GitOps commit overhead.

## 🔧 Changes Made

- [x] Rewrite `src/content/blog/cordless-terraform-self-service-provisioning.mdx` — cut prose ~60%, kept the mermaid diagram, code sample, and key highlights
- [x] Add `public/blog/cordless-terraform.svg` — custom hero image (input → workspace → live infra)
- [x] Note the pattern works with any CI system, not just GitHub Actions

## 🧪 Testing

- [x] Manual testing completed (`npm run build` succeeds, post renders with hero image and Mermaid diagram)
- [ ] Playwright tests pass (not run in this session)

## 📚 Documentation

- [ ] README updated (if needed) — not needed
- [ ] Code comments added — not needed
- [ ] API documentation updated (if applicable) — n/a

## 🚀 Deployment Notes

- [ ] Environment variables updated (if needed) — none
- [ ] Database migrations (if applicable) — n/a
- [ ] Breaking changes documented — n/a (content-only)

## ✅ Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] Linting passes (`npm run lint`)
- [x] Type checking passes (`npm run typecheck`)
- [x] Build succeeds (`npm run build`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hwg3akZCcVdennzhEDhWHE)_